### PR TITLE
Fix: Internal rout for fonts at textstyle.json

### DIFF
--- a/StreamingAssets/i18n/es/textstyle.json
+++ b/StreamingAssets/i18n/es/textstyle.json
@@ -1,6 +1,6 @@
 {
   "@CARD_TITLE": {
-    "font": "es/CardTitle SDF",
+    "font": "en/CardTitle SDF",
     "size": 45,
     "enableAutoSize": true,
     "sizeRange": [40, 50],
@@ -8,8 +8,8 @@
     "characterSpacing": -2
   },
   "@CARD_SUDAN_TITLE": {
-    "font": "es/CardTitle SDF",
-    "material": "es/CardTitle SDF - SudanTitle",
+    "font": "en/CardTitle SDF",
+    "material": "en/CardTitle SDF - SudanTitle",
     "size": 45,
     "enableAutoSize": true,
     "sizeRange": [40, 50],
@@ -22,23 +22,23 @@
     "characterSpacing": -4
   },
   "@CARD_INFO_TAG_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "enableAutoSize": true,
     "sizeRange": [26, 30],
     "characterSpacing": -4
   },
   "@CARD_INFO_TAG_FIXED_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 30,
     "characterSpacing": -4
   },
   "@CARD_INFO_TAG_TITLE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "size": 40,
     "characterSpacing": -4
   },
   "@TIPS_FORMAT": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "css_size": {
       "xs": 25,
       "sm": 30,
@@ -50,8 +50,8 @@
     "characterSpacing": -4
   },
   "@RITE_TITLE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
-    "material": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitleNew",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "material": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitleNew",
     "css_size": {
       "xs": 30,
       "sm": 35,
@@ -63,8 +63,8 @@
     "characterSpacing": -4
   },
   "@RITE_TITLE_BLACK": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
-    "material": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitleNewBlack",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "material": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitleNewBlack",
     "css_size": {
       "xs": 30,
       "sm": 35,
@@ -76,13 +76,13 @@
     "characterSpacing": -4
   },
   "@RITE_PANEL_TITLE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
-    "material": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitle",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "material": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF - RiteTitle",
     "size": 60,
     "wordSpacing": -2
   },
   "@RITE_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 28,
       "sm": 32,
@@ -94,7 +94,7 @@
     "characterSpacing": -4
   },
   "@RITE_SETTLEMENT_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 30,
       "sm": 35,
@@ -106,7 +106,7 @@
     "characterSpacing": -4
   },
   "@PROMPT_TEXT": {
-    "font": "es/Altinn-DIN SDF",
+    "font": "en/Altinn-DIN SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -121,7 +121,7 @@
     "paragraphSpacing": -69
   },
   "@OPTION_ITEM_TEXT": {
-    "font": "es/Altinn-DIN SDF",
+    "font": "en/Altinn-DIN SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -133,7 +133,7 @@
     "characterSpacing": -4
   },
   "@WIZARD_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -145,7 +145,7 @@
     "characterSpacing": -4
   },
   "@WIZARD_OPTION_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 30,
       "sm": 35,
@@ -169,7 +169,7 @@
     "characterSpacing": -4
   },
   "@POP_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -181,7 +181,7 @@
     "characterSpacing": -4
   },
   "@RITE_SETTLEMENT_POP_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 28,
       "sm": 32,
@@ -193,23 +193,23 @@
     "characterSpacing": -4
   },
   "@BIG_BUTTON": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "size": 72,
     "characterSpacing": -4
   },
   "@BIG_BUTTON_AUTO_SIZE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "enableAutoSize": true,
     "sizeRange": [40, 72],
     "characterSpacing": -4
   },
   "@BIG_BUTTON_HALF": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "size": 36,
     "characterSpacing": -4
   },
   "@MAIN_BODY": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -221,7 +221,7 @@
     "characterSpacing": -2
   },
   "@MAIN_BODY_HALF": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 20,
       "sm": 23,
@@ -232,7 +232,7 @@
     }
   },
   "@MAIN_BODY_AUTO_SIZE": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "enableAutoSize": true,
     "sizeRange": [20, 60]
   },
@@ -274,12 +274,12 @@
     "characterSpacing": -4
   },
   "@TOGGLE": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 36,
     "characterSpacing": -4
   },
   "@OVER_RECORD_SUB_NAME": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 40,
     "characterSpacing": -4
   },
@@ -291,20 +291,20 @@
     "characterSpacing": -4
   },
   "@CARD_INFO_DESC": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "enableAutoSize": true,
     "sizeRange": [18, 40],
     "wordSpacing": 0,
     "characterSpacing": -1.5
   },
   "@CARD_INFO_TYPE": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "enableAutoSize": true,
     "sizeRange": [20, 30],
     "characterSpacing": -4
   },
   "@NOTE_ITEM_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 30,
       "sm": 35,
@@ -316,12 +316,12 @@
     "characterSpacing": -4
   },
   "@SETTING_OPTION_ITEM": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 22,
     "characterSpacing": -4
   },
   "@SETTING_OPTION_TITLE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "size": 28,
     "characterSpacing": -4
   },
@@ -332,18 +332,18 @@
     "characterSpacing": -6
   },
   "@PRESTIGE_TITLE": {
-    "font": "es/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
+    "font": "en/Sweynheim&Pannartz-Subiaco-ProtoRoman120R SDF",
     "enableAutoSize": true,
     "sizeRange": [40, 60],
     "characterSpacing": -4
   },
   "@HELP_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 50,
     "characterSpacing": -4
   },
   "@GUIDE_TEXT": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "size": 75,
     "characterSpacing": -4
   },
@@ -354,7 +354,7 @@
     "characterSpacing": -4
   },
   "PROMPT_CHANGE_NAME_TITLE": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -366,7 +366,7 @@
     "characterSpacing": -4
   },
   "PROMPT_CHANGE_NAME_INPUT_PLACEHOLDER": {
-    "font": "es/Altinn-DINCondensed SDF",
+    "font": "en/Altinn-DINCondensed SDF",
     "css_size": {
       "xs": 40,
       "sm": 45,
@@ -384,15 +384,15 @@
     "wordSpacing": -6
   },
   "@OVER_TITLE": {
-    "font": "es/CardTitle SDF",
-    "material": "es/CardTitle SDF - SudanTitle",
+    "font": "en/CardTitle SDF",
+    "material": "en/CardTitle SDF - SudanTitle",
     "enableAutoSize": true,
     "sizeRange": [100, 120],
     "characterSpacing": -4
   },
   "@OVER_SUBTITLE": {
-    "font": "es/CardTitle SDF",
-    "material": "es/CardTitle SDF - SudanTitle",
+    "font": "en/CardTitle SDF",
+    "material": "en/CardTitle SDF - SudanTitle",
     "size": 50
   },
   "@PRESITGE_COUNT": {


### PR DESCRIPTION
Latin and non Latin fonts are definined at textstyle.json pointing to, probably, internal compiled resources. This edit is just a fix to for using same spanish fonts as english is using.